### PR TITLE
integration with signing device

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -23,10 +23,22 @@ window.addEventListener('message', async message => {
   if (!message.data.params) return
   if (message.data.ext !== 'horse') return
 
+  console.log('### addEventListener', message)
   // if we need the serial connection, handle it here (background.js doesn't have access)
   switch (message.data.type) {
     case 'getPublicKey': {
-      return callMethodOnDevice(METHOD_PUBLIC_KEY, [], connectionCallbacks)
+      const publicKey = await callMethodOnDevice(METHOD_PUBLIC_KEY, [], connectionCallbacks)
+      const xOnlyPublicKey = publicKey.substring(0, 64)
+      console.log('### case: xOnlyPublicKey', xOnlyPublicKey)
+      window.postMessage(
+        {
+          ext: 'horse',
+          id: message.data.id,
+          response: xOnlyPublicKey
+        },
+        '*'
+      )
+      return publicKey
     }
     case 'signEvent': {
       let {event} = message.data.params
@@ -76,25 +88,28 @@ chrome.runtime.onMessage.addListener(async (req, sender) => {
 
 const connectionCallbacks = {
   onConnect() {
-    console.log('wqwewqel')
-    chrome.action.setBadgeBackgroundColor({color: 'green'})
-    chrome.action.setBadgeText({text: 'on'})
-    chrome.runtime.sendMessage({isConnected: true})
+    console.log('### chrome.action', chrome.action)
+    // chrome.action.setBadgeBackgroundColor({color: 'green'})
+    // chrome.action.setBadgeText({text: 'on'})
+    // chrome.runtime.sendMessage({isConnected: true})
   },
   onDisconnect() {
-    chrome.action.setBadgeText({text: ''})
-    chrome.runtime.sendMessage({isConnected: false})
+    console.log('### onDisconnect')
+    // chrome.action.setBadgeText({text: ''})
+    // chrome.runtime.sendMessage({isConnected: false})
   },
   onDone() {
-    chrome.action.setBadgeBackgroundColor({color: 'black'})
-    chrome.action.setBadgeText({text: 'done'})
-    chrome.runtime.sendMessage({isConnected: false})
+    console.log('### onDone')
+    // chrome.action.setBadgeBackgroundColor({color: 'black'})
+    // chrome.action.setBadgeText({text: 'done'})
+    // chrome.runtime.sendMessage({isConnected: false})
   },
   onError(error) {
-    chrome.action.setBadgeBackgroundColor({color: 'red'})
-    chrome.action.setBadgeText({text: 'err'})
-    chrome.runtime.sendMessage({isConnected: false})
-    chrome.runtime.sendMessage({serialError: error})
+    console.log('### onError', error)
+    // chrome.action.setBadgeBackgroundColor({color: 'red'})
+    // chrome.action.setBadgeText({text: 'err'})
+    // chrome.runtime.sendMessage({isConnected: false})
+    // chrome.runtime.sendMessage({serialError: error})
   }
 }
 

--- a/extension/nostr-provider.js
+++ b/extension/nostr-provider.js
@@ -9,7 +9,7 @@ window.nostr = {
   },
 
   async signEvent(event) {
-    return this._call('signEvent', {event})
+    return await this._call('signEvent', {event})
   },
 
   async getRelays() {


### PR DESCRIPTION
### Summary
- integration with signing device

**Changes**
 - the callback for `port.addEventListener('connect' ...)` is never triggered. I don't know why!
   - the logic has been moved to `startSerialPortReading()` which is called after a delay (yeah ugly, but it works)
   - the `addEventListener` mode is cleaner and follows the patterns. If someone can figure out how to make it work then the `startSerialPortReading()` should be moved back here

 - reply to `_call()` using `window.postMessage()` 
 - `chrome.action` is `undefined`. I've just commented that code.
