### PR TITLE
Support direct messages (`encrypt`/`decrypt`)

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -4,8 +4,11 @@ import { validateEvent, getEventHash } from 'nostr-tools'
 import {
   callMethodOnDevice,
   METHOD_PUBLIC_KEY,
-  METHOD_SIGN_MESSAGE
+  METHOD_SIGN_MESSAGE,
+  METHOD_SHARED_SECRET
 } from './serial'
+
+import { decrypt, encrypt, xOnlyToXY } from './utils'
 
 // inject the script that will provide window.nostr
 let script = document.createElement('script')
@@ -22,7 +25,7 @@ window.addEventListener('message', async message => {
   if (message.data.ext !== 'horse') return
 
   // if we need the serial connection, handle it here (background.js doesn't have access)
-  const response = await hanleMessage(message)
+  const response = await handleMessage(message)
 
   // return response
   window.postMessage(
@@ -31,7 +34,7 @@ window.addEventListener('message', async message => {
   )
 })
 
-const hanleMessage = async (message) => {
+const handleMessage = async (message) => {
   try {
     switch (message.data.type) {
       case 'getPublicKey': {
@@ -54,7 +57,6 @@ const hanleMessage = async (message) => {
         if (!event.id) event.id = getEventHash(event)
         if (!validateEvent(event)) return { error: { message: 'invalid event' } }
 
-        console.log('### signEvent', event)
         event.sig = await callMethodOnDevice(
           METHOD_SIGN_MESSAGE,
           [event.id],
@@ -63,12 +65,39 @@ const hanleMessage = async (message) => {
         return event
       }
       case 'nip04.encrypt': {
-        // let {peer, plaintext} = params
-        throw new Error('not implemented')
+        const { peer, plaintext } = message.data.params
+        if (!peer) {
+          throw new Error('Cannot encrypt message!')
+        }
+        const sharedSecret = await callMethodOnDevice(
+          METHOD_SHARED_SECRET,
+          [xOnlyToXY(peer)],
+          connectionCallbacks
+        )
+        console.log('### peer', peer)
+        console.log('### plaintext', plaintext)
+        console.log('### sharedSecret', sharedSecret)
+        const ecnryptedText = await encrypt(sharedSecret, plaintext)
+        console.log('### ecnryptedText', ecnryptedText)
+        // throw new Error('not implemented, nip04.encrypt')
+        return ecnryptedText
       }
       case 'nip04.decrypt': {
-        // let {peer, ciphertext} = params
-        throw new Error('not implemented')
+        const { peer, ciphertext } = message.data.params
+        if (!peer || !ciphertext) {
+          throw new Error('Cannot decrypt message!')
+        }
+        const sharedSecret = await callMethodOnDevice(
+          METHOD_SHARED_SECRET,
+          [xOnlyToXY(peer)],
+          connectionCallbacks
+        )
+        console.log('### peer', peer)
+        console.log('### plaintext', ciphertext)
+        console.log('### sharedSecret', sharedSecret)
+        const plainText = await decrypt(sharedSecret, ciphertext)
+        console.log('### ecnryptedText', plainText)
+        return plainText
       }
       default: {
         // pass on to background

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -11,7 +11,7 @@ import {
 import { decrypt, encrypt, xOnlyToXY } from './utils'
 
 // inject the script that will provide window.nostr
-let script = document.createElement('script')
+const script = document.createElement('script')
 script.setAttribute('async', 'false')
 script.setAttribute('type', 'text/javascript')
 script.setAttribute('src', chrome.runtime.getURL('nostr-provider.js'))
@@ -45,7 +45,7 @@ const handleMessage = async (message) => {
         )
       }
       case 'signEvent': {
-        let { event } = message.data.params
+        const { event } = message.data.params
 
         if (!event.pubkey)
           event.pubkey = await callMethodOnDevice(

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,6 +1,6 @@
 /* globals chrome */
 
-import {validateEvent, getEventHash} from 'nostr-tools'
+import { validateEvent, getEventHash } from 'nostr-tools'
 import {
   callMethodOnDevice,
   METHOD_PUBLIC_KEY,
@@ -22,78 +22,80 @@ window.addEventListener('message', async message => {
   if (message.data.ext !== 'horse') return
 
   // if we need the serial connection, handle it here (background.js doesn't have access)
-  switch (message.data.type) {
-    case 'getPublicKey': {
-      response = await callMethodOnDevice(
-        METHOD_PUBLIC_KEY,
-        [],
-        connectionCallbacks
-      )
-      break
-    }
-    case 'signEvent': {
-      let {event} = message.data.params
+  const response = await hanleMessage(message)
 
-      if (!event.pubkey)
-        event.pubkey = await callMethodOnDevice(
+  // return response
+  window.postMessage(
+    { id: message.data.id, ext: 'horse', response },
+    message.origin
+  )
+})
+
+const hanleMessage = async (message) => {
+  try {
+    switch (message.data.type) {
+      case 'getPublicKey': {
+        return await callMethodOnDevice(
           METHOD_PUBLIC_KEY,
           [],
           connectionCallbacks
         )
-      if (!event.created_at) event.created_at = Math.round(Date.now() / 1000)
-      if (!event.id) event.id = getEventHash(event)
-      if (!validateEvent(event)) return {error: {message: 'invalid event'}}
+      }
+      case 'signEvent': {
+        let { event } = message.data.params
 
-      event.sig = await callMethodOnDevice(
-        METHOD_SIGN_MESSAGE,
-        [event.id],
-        connectionCallbacks
-      )
-      response = event
-      break
-    }
-    case 'nip04.encrypt': {
-      // let {peer, plaintext} = params
-      throw new Error('not implemented')
-    }
-    case 'nip04.decrypt': {
-      // let {peer, ciphertext} = params
-      throw new Error('not implemented')
-    }
-    default: {
-      // pass on to background
-      var response
-      try {
-        response = await chrome.runtime.sendMessage({
+        if (!event.pubkey)
+          event.pubkey = await callMethodOnDevice(
+            METHOD_PUBLIC_KEY,
+            [],
+            connectionCallbacks
+          )
+        if (!event.created_at) event.created_at = Math.round(Date.now() / 1000)
+        if (!event.id) event.id = getEventHash(event)
+        if (!validateEvent(event)) return { error: { message: 'invalid event' } }
+
+        console.log('### signEvent', event)
+        event.sig = await callMethodOnDevice(
+          METHOD_SIGN_MESSAGE,
+          [event.id],
+          connectionCallbacks
+        )
+        return event
+      }
+      case 'nip04.encrypt': {
+        // let {peer, plaintext} = params
+        throw new Error('not implemented')
+      }
+      case 'nip04.decrypt': {
+        // let {peer, ciphertext} = params
+        throw new Error('not implemented')
+      }
+      default: {
+        // pass on to background
+        return await chrome.runtime.sendMessage({
           type: message.data.type,
           params: message.data.params,
           host: location.host,
           cs: true
         })
-      } catch (error) {
-        response = {error}
       }
     }
+  } catch (error) {
+    return { error }
   }
-
-  // return response
-  window.postMessage(
-    {id: message.data.id, ext: 'horse', response},
-    message.origin
-  )
-})
+}
 
 const connectionCallbacks = {
   onConnect() {
-    chrome.runtime.sendMessage({connect: true, serial: true})
+    chrome.runtime.sendMessage({ connect: true, serial: true })
   },
   onDisconnect() {
-    chrome.runtime.sendMessage({disconnect: true, serial: true})
+    chrome.runtime.sendMessage({ disconnect: true, serial: true })
   },
   onDone() {
-    chrome.runtime.sendMessage({done: true, serial: true})
+    chrome.runtime.sendMessage({ done: true, serial: true })
   },
   onError(error) {
-    chrome.runtime.sendMessage({error, serial: true})
+    chrome.runtime.sendMessage({ error, serial: true })
   }
 }

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -74,12 +74,7 @@ const handleMessage = async (message) => {
           [xOnlyToXY(peer)],
           connectionCallbacks
         )
-        console.log('### peer', peer)
-        console.log('### plaintext', plaintext)
-        console.log('### sharedSecret', sharedSecret)
         const ecnryptedText = await encrypt(sharedSecret, plaintext)
-        console.log('### ecnryptedText', ecnryptedText)
-        // throw new Error('not implemented, nip04.encrypt')
         return ecnryptedText
       }
       case 'nip04.decrypt': {
@@ -92,11 +87,7 @@ const handleMessage = async (message) => {
           [xOnlyToXY(peer)],
           connectionCallbacks
         )
-        console.log('### peer', peer)
-        console.log('### plaintext', ciphertext)
-        console.log('### sharedSecret', sharedSecret)
         const plainText = await decrypt(sharedSecret, ciphertext)
-        console.log('### ecnryptedText', plainText)
         return plainText
       }
       default: {

--- a/extension/serial.js
+++ b/extension/serial.js
@@ -73,10 +73,17 @@ export async function initDevice({ onConnect, onDisconnect, onError, onDone }) {
               lastCommand = 0
               resolveCommand(data)
             }
-            if (done) return
+            if (done) {
+              lastCommand = 0
+              writer = null
+              onDone()
+              return
+            }
             onDone()
           }
         } catch (error) {
+          lastCommand = 0
+          writer = null
           onError(error.message)
           throw error
         }
@@ -85,7 +92,7 @@ export async function initDevice({ onConnect, onDisconnect, onError, onDone }) {
 
     port.open({ baudRate: 9600 })
 
-    // this `sleep()` is a hack, I know!!!
+    // this `sleep()` is a hack, I know!
     // but `port.onconnect` is never called. I don't know why!
     await sleep(1000)
     startSerialPortReading()
@@ -103,6 +110,7 @@ export async function initDevice({ onConnect, onDisconnect, onError, onDone }) {
 
     port.addEventListener('disconnect', () => {
       console.log('disconnected from device')
+      lastCommand = 0
       writer = null
       onDisconnect()
     })

--- a/extension/serial.js
+++ b/extension/serial.js
@@ -22,7 +22,6 @@ export function isConnected() {
 }
 
 export async function callMethodOnDevice(method, params, opts) {
-  console.log('### callMethodOnDevice', method, params, opts)
   try {
     if (!writer) await initDevice(opts)
   } catch (err) {
@@ -33,22 +32,16 @@ export async function callMethodOnDevice(method, params, opts) {
   // only one command can be pending at any time
   // but each will only wait 6 seconds
   if (lastCommand > Date.now() + 6000) {
-    console.log('#### lastCommand !!!')
     throw new Error('Previous command to device still pending!')
   }
   lastCommand = Date.now()
 
   return new Promise(async (resolve, reject) => {
-    try {
-      setTimeout(reject, 6000)
-      resolveCommand = resolve
+    setTimeout(reject, 6000)
+    resolveCommand = resolve
 
-      // send actual command
-      sendCommand(method, params)
-      console.log('### sent command', method, params)
-    } catch (error) {
-      reject(error)
-    }
+    // send actual command
+    sendCommand(method, params)
   })
 }
 
@@ -79,7 +72,6 @@ export async function initDevice({ onConnect, onDisconnect, onError, onDone }) {
                 }
 
                 lastCommand = 0
-                console.log('### resolveCommand', data)
                 resolveCommand(data)
               }
               if (done) return

--- a/extension/serial.js
+++ b/extension/serial.js
@@ -47,8 +47,15 @@ export async function callMethodOnDevice(method, params, opts) {
 
 export async function initDevice({ onConnect, onDisconnect, onError, onDone }) {
   return new Promise(async (resolve, reject) => {
-    const port = await navigator.serial.requestPort()
+    let port = null
     let reader
+    try {
+      port = await navigator.serial.requestPort()
+    } catch (error) {
+      reject(error)
+      return
+    }
+
 
     const startSerialPortReading = async () => {
       // reading responses
@@ -62,7 +69,7 @@ export async function initDevice({ onConnect, onDisconnect, onError, onDone }) {
           while (true) {
             const { value, done } = await readStringUntil('\n')
             if (value) {
-              let { method, data } = parseResponse(value)
+              const { method, data } = parseResponse(value)
               console.log('serial port data: ', method, data)
 
               if (PUBLIC_METHODS.indexOf(method) === -1) {

--- a/extension/serial.js
+++ b/extension/serial.js
@@ -86,7 +86,6 @@ export async function initDevice({ onConnect, onDisconnect, onError, onDone }) {
               onDone()
               return
             }
-            onDone()
           }
         } catch (error) {
           lastCommand = 0

--- a/extension/utils.js
+++ b/extension/utils.js
@@ -1,0 +1,54 @@
+import { base64 } from '@scure/base'
+import { randomBytes, hexToBytes } from '@noble/hashes/utils'
+import { Point } from '@noble/secp256k1'
+
+export const utf8Decoder = new TextDecoder('utf-8')
+export const utf8Encoder = new TextEncoder()
+
+
+export async function encrypt(sharedSecret, text) {
+    sharedSecret = hexToBytes(sharedSecret)
+    let iv = Uint8Array.from((0, randomBytes)(16))
+    let plaintext = utf8Encoder.encode(text)
+    let cryptoKey = await crypto.subtle.importKey(
+        'raw',
+        sharedSecret,
+        { name: 'AES-CBC' },
+        false,
+        ['encrypt']
+    )
+    let ciphertext = await crypto.subtle.encrypt(
+        { name: 'AES-CBC', iv },
+        cryptoKey,
+        plaintext
+    )
+    let ctb64 = base64.encode(new Uint8Array(ciphertext))
+    let ivb64 = base64.encode(new Uint8Array(iv.buffer))
+    return `${ctb64}?iv=${ivb64}`
+}
+
+export async function decrypt(sharedSecret, data) {
+    sharedSecret = hexToBytes(sharedSecret)
+    let [ctb64, ivb64] = data.split('?iv=')
+    let cryptoKey = await crypto.subtle.importKey(
+        'raw',
+        sharedSecret,
+        { name: 'AES-CBC' },
+        false,
+        ['decrypt']
+    )
+    let ciphertext = base64.decode(ctb64)
+    let iv = base64.decode(ivb64)
+    let plaintext = await crypto.subtle.decrypt(
+        { name: 'AES-CBC', iv },
+        cryptoKey,
+        ciphertext
+    )
+    let text = utf8Decoder.decode(plaintext)
+    return text
+}
+
+
+export function xOnlyToXY(p) {
+    return Point.fromHex(p).toHex().substring(2)
+}


### PR DESCRIPTION
### Summary
- support `encrypt` and `decrypt` for DMs
- the hardware device only computes the shared secret
   - the `encrypt/decrypt` is done on the extension side, not on the device side
- this version of the extension does NOT cache the `sharedSecret` for a particular peer
  - instead it fetches it each time from the device
  - it can be a bit slower, but it is safer. Once the hardware device is removed new DMs cannot be sent or read.

**Notes**:
- `nip04.ecrypt` and `nip04.decrypt` expect a privateKey + publicKey and compute the `sharedSecret`. 
  - this interface will have to be updated in order to support a `sharedSecret` computed outside these functions
  - as a temp solution the `sharedSecret` versions have been added to `utils.js`

- the `/shared-secret {peerPubkey}` command for the device expects a public key of the form (x,y)
  - that is 64 bytes, the first 32 contain the `x` coordinate, the next 32 the `y`
  -`04` prefix must NOT be used
  - this is due to a limitation on the libraries of the device (most likely a limitation on me understanding these libs)